### PR TITLE
Delete SVN files before merging with Git

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -65,6 +65,9 @@ echo
 echo "Creating local copy of SVN repo ..."
 svn co $SVNURL $SVNPATH
 
+echo "Clearing svn repo so we can overwrite it"
+svn rm $SVNPATH/trunk/*
+
 echo "Exporting the HEAD of master from git to the trunk of SVN"
 git checkout-index -a -f --prefix=$SVNPATH/trunk/
 


### PR DESCRIPTION
Deleting the SVN files first means that if a file has been removed from the Git repo, it doesn't continue to live on in the SVN repo. Fixes https://github.com/thenbrent/multisite-user-management/issues/16
